### PR TITLE
Store record_type for Draft posts

### DIFF
--- a/app/controllers/charitable_organizations_controller.rb
+++ b/app/controllers/charitable_organizations_controller.rb
@@ -21,7 +21,7 @@ class CharitableOrganizationsController < ApplicationController
         render :new
       end
     else
-      draft = Draft.new(info: charitable_organization_update_params.merge({record_type: CharitableOrganization.name}), created_by: current_user)
+      draft = Draft.new(info: charitable_organization_update_params, record_type: CharitableOrganization, created_by: current_user)
 
       if draft.save
         redirect_to draft, notice: 'Your new Charitable Organization is pending approval.'

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -30,7 +30,8 @@ class DraftsController < ApplicationController
 
   def set_record
     @draft = Draft.find(params[:id])
-    if(@draft.record)
+
+    if @draft.record
       @record = @draft.record
     else
       @record = @draft.record_type.constantize.new

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -24,7 +24,7 @@ class LocationsController < ApplicationController
         render :new
       end
     else
-      draft = Draft.new(info: location_draft_params, created_by: current_user)
+      draft = Draft.new(info: location_draft_params, record_type: Location, created_by: current_user)
 
       if draft.save
         path = location_draft_path(organization: @organization, legacy_table_name: @legacy_table_name, id: draft.id)

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -22,7 +22,7 @@ class SheltersController < ApplicationController
         render :new
       end
     else
-      draft = Draft.new(info: shelter_update_params.merge({record_type: Shelter.name}), created_by: current_user)
+      draft = Draft.new(info: shelter_update_params, created_by: current_user, record_type: Shelter)
 
       if draft.save
         redirect_to draft, notice: 'Your new shelter is pending approval.'

--- a/test/controllers/drafts_controller_test.rb
+++ b/test/controllers/drafts_controller_test.rb
@@ -4,7 +4,7 @@ class DraftsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   def drafts
-    Draft.where("info->'record_type' is not null").all
+    Draft.where("record_type is not null").all
   end
 
   test "loads show for all types" do

--- a/test/fixtures/drafts.yml
+++ b/test/fixtures/drafts.yml
@@ -1,6 +1,6 @@
 new_need:
+  record_type: "Need"
   info:
-    record_type: "Need"
     location_name: "Grace Goodwill"
     location_address: "1301 Fannin St"
     are_volunteers_needed: false
@@ -13,12 +13,11 @@ new_need:
 update_need:
   record: katy (Need)
   info:
-    record_type: "Need"
     tell_us_about_the_volunteer_needs: "we need trained medical personel"
 
 new_shelter:
+  record_type: "Shelter"
   info:
-    record_type: "Shelter"
     shelter: "Toyota Center "
     address: "1001 Fannin St"
     city: "Houston"
@@ -34,10 +33,10 @@ new_shelter:
 update_shelter:
   record: nrg (Shelter)
   info:
-    record_type: "Shelter"
     pets: "No"
 
 new_charitable_organization:
+  record_type: "CharitableOrganization"
   info:
     name: "Hope"
     services: church
@@ -49,33 +48,8 @@ new_charitable_organization:
     city: "humble"
     state: "tx"
     zip: "12345"
-    record_type: "CharitableOrganization"
 
 update_charitable_organization:
   record: one (CharitableOrganization)
   info:
-    record_type: "CharitableOrganization"
     food_bank: true
-
-new_rescuee:
-  info:
-    name: "Bobby B."
-    address: "1401 Fannin"
-    city: "Houston"
-    state: "TX"
-    phone: "555-555-5555"
-    organization: "hurricane-harvey-rescue-dispatchers"
-    legacy_table_name: "rescuees"
-    apartment_number: 
-    status: "Boat in Route"
-    tier: "None"
-    high_water_vehicle_accessible: false
-    number_of_adults: "2"
-    number_of_elderly: "0"
-    number_of_children: "2"
-    number_of_pets: "1"
-
-update_rescuee:
-  record: family_rescuees (Location)
-  info:
-    status: "Rescued"


### PR DESCRIPTION
When accepting a Draft, the controller uses its `record_type` field to
instantiate the right object. Rather than merging the record_type into
the info hash, let's keep it at the top-level for the object.