### PR TITLE
Format timestamps as relative time in admin table

### DIFF
--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -13,7 +13,17 @@
       <tr>
         <td><%= link_to 'Show', row %> / <%= link_to 'Update', [:edit, row] %></td>
         <% columns.each do |column| %>
-          <td><%= truncate(row.send(column).to_s) %></td>
+          <% value = row.send(column) %>
+          <% if value.acts_like?(:time) %>
+            <td data-order="<%= value.to_i %>">
+              <span title="<%= value %>"><%= time_ago_in_words(value) %> ago</span>
+            </td>
+          <% else %>
+            <td>
+              <%= truncate(value.to_s) %>
+            </td>
+            <% end %>
+          </td>
         <% end %>
       </tr>
     <% end %>


### PR DESCRIPTION
This will help volunteers keep track of when records were updated
without having to convert timestamps or deal with UTC.

![image](https://user-images.githubusercontent.com/129120/45459780-ccb85f80-b6ae-11e8-9d89-283ef7a0fd07.png)
