### PR TITLE
Fix footer to point to the florence repo instead of the harvey one.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
     </div>
 
     <footer>
-      Code is available at <a href="http://github.com/sketch-city/harvey-api">GitHub</a>. Contributors welcome!
+      Code is available at <a href="http://github.com/hurricane-response/florence-api">GitHub</a>. Contributors welcome!
     </footer>
     <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_JS_API_KEY'] %>&libraries=places"></script>
     <% if ENV["GOOGLE_MAPS_JS_API_KEY"].blank? %>


### PR DESCRIPTION
Footer was pointing to the original `harvey-api` repo. If we want contributors to help with this site, we need to point them to the correct codebase.