### PR TITLE
[DB Migration] [Depends on #30] Accessibility field

### DIFF
--- a/app/controllers/api/v1/shelters_controller.rb
+++ b/app/controllers/api/v1/shelters_controller.rb
@@ -34,6 +34,11 @@ class Api::V1::SheltersController < ApplicationController
       @shelters = @shelters.where(special_needs: true)
     end
 
+    if params[:accessibility].present?
+      @filters[:accessibility] = params[:accessibility]
+      @shelters = @shelters.where("accessibility ILIKE ?", "%#{@filters[:accessibility]}%")
+    end
+
     if params[:unofficial].present?
       @filters[:unofficial] = params[:unofficial]
       @shelters = @shelters.where(unofficial: true)

--- a/app/importers/api_importer.rb
+++ b/app/importers/api_importer.rb
@@ -7,10 +7,16 @@ class APIImporter
   format :json
 
   def self.needs
-    get('/needs')["needs"]
+    get('/needs')['needs']
   end
 
   def self.shelters
-    get('/shelters')["shelters"]
+    get('/shelters')['shelters'].map do |shelter|
+      shelter['allow_pets'] = if shelter['pets'] == 'Yes' then true
+                              elsif shelter['pets'] == 'No' then false
+                              end
+      shelter['pets'] = shelter['pets_notes']
+      shelter.except!('pets_notes')
+    end
   end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -3,7 +3,7 @@ class Shelter < ApplicationRecord
     id accepting address address_name city state county zip
     google_place_id notes allow_pets pets phone shelter source supply_needs updated_by
     volunteer_needs distribution_center food_pantry updated_at latitude
-    longitude special_needs unofficial
+    longitude accessibility unofficial
   ]
 
   # columns to hide in index view
@@ -17,6 +17,7 @@ class Shelter < ApplicationRecord
     latitude
     longitude
     notes
+    special_needs
   ]
 
   HeaderNames = ColumnNames.map(&:titleize)
@@ -24,7 +25,7 @@ class Shelter < ApplicationRecord
   UpdateFields = %w[
     accepting address address_name city state county zip notes allow_pets pets phone
     shelter source supply_needs updated_by volunteer_needs distribution_center
-    food_pantry latitude longitude google_place_id special_needs unofficial
+    food_pantry latitude longitude google_place_id accessibility unofficial
   ]
 
   PrivateFields = %w[
@@ -39,7 +40,7 @@ class Shelter < ApplicationRecord
     id updated_at updated_by phone accepting address address_name
     city state county zip google_place_id notes allow_pets pets shelter
     source supply_needs volunteer_needs distribution_center food_pantry
-    latitude longitude special_needs unofficial
+    latitude longitude accessibility unofficial
   ]
 
   has_many :drafts, as: :record
@@ -53,7 +54,7 @@ class Shelter < ApplicationRecord
 
   def self.to_csv
     attributes = %w[
-      shelter address city state county zip phone updated_at source accepting pets
+      shelter address city state county zip phone updated_at source accepting pets accessibility
     ]
     CSV.generate(headers: true) do |csv|
       csv << attributes

--- a/app/views/shelters/_form.html.erb
+++ b/app/views/shelters/_form.html.erb
@@ -88,8 +88,8 @@
     <%= f.label :food_pantry %>
     <%= f.text_field :food_pantry, :placeholder => 'Food Pantries hellping with this shelter' %>
 
-    <%= f.label :special_needs %>
-    <%= f.check_box :special_needs %>
+    <%= f.label :accessibility %>
+    <%= f.text_field :accessibility, :placeholder => 'Wheelchair accessible, or other accommodations for people with special needs?' %>
 
     <%= f.hidden_field :address, :id => 'geocode-address' %>
     <%= f.hidden_field :city, :id => 'geocode-city' %>

--- a/db/migrate/20180915035427_add_accessbility_text_field_to_shelters.rb
+++ b/db/migrate/20180915035427_add_accessbility_text_field_to_shelters.rb
@@ -1,0 +1,5 @@
+class AddAccessbilityTextFieldToShelters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :shelters, :accessibility, :text
+  end
+end

--- a/db/migrate/20180915035427_add_accessbility_text_field_to_shelters.rb
+++ b/db/migrate/20180915035427_add_accessbility_text_field_to_shelters.rb
@@ -1,5 +1,11 @@
 class AddAccessbilityTextFieldToShelters < ActiveRecord::Migration[5.1]
-  def change
+  def up
     add_column :shelters, :accessibility, :text
+    Shelter.where(special_needs: true).update_all(accessibility: 'Yes (more detail needed)')
+    Shelter.where(special_needs: false).update_all(accessibility: 'No')
+  end
+
+  def down
+    remove_column :shelters, :accessibility
   end
 end

--- a/db/migrate/20180915042245_backfill_accessibility_from_special_needs.rb
+++ b/db/migrate/20180915042245_backfill_accessibility_from_special_needs.rb
@@ -1,6 +1,0 @@
-class BackfillAccessibilityFromSpecialNeeds < ActiveRecord::Migration[5.1]
-  def change
-    Shelter.where(special_needs: true).update_all(accessibility: 'Yes (more detail needed)')
-    Shelter.where(special_needs: false).update_all(accessibility: 'No')
-  end
-end

--- a/db/migrate/20180915042245_backfill_accessibility_from_special_needs.rb
+++ b/db/migrate/20180915042245_backfill_accessibility_from_special_needs.rb
@@ -1,0 +1,6 @@
+class BackfillAccessibilityFromSpecialNeeds < ActiveRecord::Migration[5.1]
+  def change
+    Shelter.where(special_needs: true).update_all(accessibility: 'Yes (more detail needed)')
+    Shelter.where(special_needs: false).update_all(accessibility: 'No')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 20180915042245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "amazon_products", force: :cascade do |t|
     t.string "need"
@@ -178,9 +177,9 @@ ActiveRecord::Schema.define(version: 20180915042245) do
     t.string "google_place_id"
     t.boolean "special_needs"
     t.string "private_email"
-    t.boolean "allow_pets"
     t.string "private_sms"
     t.string "private_volunteer_data_mgr"
+    t.boolean "allow_pets"
     t.boolean "unofficial"
     t.text "accessibility"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170910045633) do
+<<<<<<< HEAD
+ActiveRecord::Schema.define(version: 20180915035427) do
+=======
+ActiveRecord::Schema.define(version: 20180915042245) do
+>>>>>>> e7a0b85... DB migrations to add the new field and set values according to the old one
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +146,10 @@ ActiveRecord::Schema.define(version: 20170910045633) do
     t.datetime "updated_at", null: false
   end
 
+<<<<<<< HEAD
+# Could not dump table "shelters" because of following StandardError
+#   Unknown type 'shelter_accepting_value' for column 'accepting'
+=======
   create_table "shelters", force: :cascade do |t|
     t.string "county"
     t.string "shelter"
@@ -174,7 +182,9 @@ ActiveRecord::Schema.define(version: 20170910045633) do
     t.string "private_sms"
     t.string "private_volunteer_data_mgr"
     t.boolean "unofficial"
+    t.text "accessibility"
   end
+>>>>>>> e7a0b85... DB migrations to add the new field and set values according to the old one
 
   create_table "users", force: :cascade do |t|
     t.boolean "admin"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 20180915035427) do
-=======
-ActiveRecord::Schema.define(version: 20180915042245) do
->>>>>>> e7a0b85... DB migrations to add the new field and set values according to the old one
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,10 +141,6 @@ ActiveRecord::Schema.define(version: 20180915042245) do
     t.datetime "updated_at", null: false
   end
 
-<<<<<<< HEAD
-# Could not dump table "shelters" because of following StandardError
-#   Unknown type 'shelter_accepting_value' for column 'accepting'
-=======
   create_table "shelters", force: :cascade do |t|
     t.string "county"
     t.string "shelter"
@@ -183,7 +175,6 @@ ActiveRecord::Schema.define(version: 20180915042245) do
     t.boolean "unofficial"
     t.text "accessibility"
   end
->>>>>>> e7a0b85... DB migrations to add the new field and set values according to the old one
 
   create_table "users", force: :cascade do |t|
     t.boolean "admin"


### PR DESCRIPTION
This adds a new field `accessibility` to shelters, allowing text input instead of just a checkbox.

In addition, it sets the value of that field to `Yes (more detail needed)` in the case the existing `special_needs` is `true`, `No` in the case `special_needs` is `false`, and leaves it blank in the case that `special_needs` is not set.

It hides the `special_needs` field from the tabular display and form, in favor of showing the `accessibility` field instead.

Note that this involves two database migrations:

* One adds the new field
* The other backfills the values of the new field based on existing data

For the backfilling migration, note that this has the side effect of resetting the `updated_at` field for each of these rows as well. There's nothing we can do about this, unfortunately.

Once merged, this will close #5.

I'd appreciate a review before this one gets merged.