### PR TITLE
"Shelters Needing Updates" view fixes

### DIFF
--- a/app/controllers/api/v1/shelters_controller.rb
+++ b/app/controllers/api/v1/shelters_controller.rb
@@ -5,19 +5,16 @@ class Api::V1::SheltersController < ApplicationController
   end
 
   def index
-    @shelters, @filters = apply_params(Shelter.all, params)
+    @shelters, @filters = apply_params(Shelter.all)
   end
 
   def outdated
-    @outdated, @filters = apply_params(
-      Shelter.where("updated_at < ?", 4.hours.ago).order('updated_at DESC'),
-      params
-    )
+    @outdated, @filters = apply_params(Shelter.outdated.order('updated_at DESC'))
   end
 
   private
 
-  def apply_params(shelters, params)
+  def apply_params(shelters)
     filters = {}
 
     if params[:lat].present? && params[:lon].present?
@@ -33,17 +30,17 @@ class Api::V1::SheltersController < ApplicationController
 
     if params[:shelter].present?
       filters[:shelter] = params[:shelter]
-      shelters = @shelters.where("shelter ILIKE ?", "%#{@filters[:shelter]}%")
+      shelters = shelters.where("shelter ILIKE ?", "%#{@filters[:shelter]}%")
     end
 
     if params[:accepting].present?
       filters[:accepting] = params[:accepting]
-      shelters = @shelters.where(accepting: true)
+      shelters = shelters.where(accepting: true)
     end
 
     if params[:special_needs].present?
       filters[:special_needs] = params[:special_needs]
-      shelters = @shelters.where(special_needs: true)
+      shelters = shelters.where(special_needs: true)
     end
 
     if params[:unofficial].present?

--- a/app/controllers/api/v1/shelters_controller.rb
+++ b/app/controllers/api/v1/shelters_controller.rb
@@ -5,43 +5,56 @@ class Api::V1::SheltersController < ApplicationController
   end
 
   def index
-    @filters = {}
-    @shelters = Shelter.all
+    @shelters, @filters = apply_params(Shelter.all, params)
+  end
+
+  def outdated
+    @outdated, @filters = apply_params(
+      Shelter.where("updated_at < ?", 4.hours.ago).order('updated_at DESC'),
+      params
+    )
+  end
+
+  private
+
+  def apply_params(shelters, params)
+    filters = {}
 
     if params[:lat].present? && params[:lon].present?
-      @filters[:lon] = params[:lon]
-      @filters[:lat] = params[:lat]
-      @shelters = @shelters.near([params[:lat], params[:lon]], 100)
+      filters[:lon] = params[:lon]
+      filters[:lat] = params[:lat]
+      shelters = shelters.near([params[:lat], params[:lon]], 100)
     end
 
     if params[:county].present?
-      @filters[:county] = params[:county]
-      @shelters = @shelters.where("county ILIKE ?", "%#{@filters[:county]}%")
+      filters[:county] = params[:county]
+      shelters = shelters.where("county ILIKE ?", "%#{@filters[:county]}%")
     end
 
     if params[:shelter].present?
-      @filters[:shelter] = params[:shelter]
-      @shelters = @shelters.where("shelter ILIKE ?", "%#{@filters[:shelter]}%")
+      filters[:shelter] = params[:shelter]
+      shelters = @shelters.where("shelter ILIKE ?", "%#{@filters[:shelter]}%")
     end
 
     if params[:accepting].present?
-      @filters[:accepting] = params[:accepting]
-      @shelters = @shelters.where(accepting: true)
+      filters[:accepting] = params[:accepting]
+      shelters = @shelters.where(accepting: true)
     end
 
     if params[:special_needs].present?
-      @filters[:special_needs] = params[:special_needs]
-      @shelters = @shelters.where(special_needs: true)
+      filters[:special_needs] = params[:special_needs]
+      shelters = @shelters.where(special_needs: true)
     end
 
     if params[:unofficial].present?
-      @filters[:unofficial] = params[:unofficial]
-      @shelters = @shelters.where(unofficial: true)
+      filters[:unofficial] = params[:unofficial]
+      shelters = shelters.where(unofficial: true)
     end
 
-    if params[:limit].to_i > 0
-      @shelters = @shelters.limit(params[:limit].to_i)
+    if params[:limit].to_i.positive?
+      shelters = shelters.limit(params[:limit].to_i)
     end
+
+    [shelters, filters]
   end
-
 end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -82,7 +82,7 @@ class SheltersController < ApplicationController
   end
 
   def outdated
-    @outdated = Shelter.where("updated_at < ?", 4.hours.ago).order('updated_at DESC')
+    @outdated = Shelter.outdated.order('updated_at DESC')
     columns = Shelter::OutdatedViewColumnNames - Shelter::IndexHiddenColumnNames
     @columns = columns
     @headers = columns.map(&:titleize)

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,6 +1,6 @@
 class Shelter < ApplicationRecord
   ColumnNames = %w[
-    id accepting address address_name city state county zip
+    id accepting address address_name city county state zip
     google_place_id notes allow_pets pets phone shelter source supply_needs updated_by
     volunteer_needs distribution_center food_pantry updated_at latitude
     longitude special_needs unofficial
@@ -10,9 +10,6 @@ class Shelter < ApplicationRecord
   IndexHiddenColumnNames = %w[
     address_name
     allow_pets
-    city
-    state
-    zip
     google_place_id
     latitude
     longitude
@@ -22,7 +19,7 @@ class Shelter < ApplicationRecord
   HeaderNames = ColumnNames.map(&:titleize)
 
   UpdateFields = %w[
-    accepting address address_name city state county zip notes allow_pets pets phone
+    accepting address address_name city county state zip notes allow_pets pets phone
     shelter source supply_needs updated_by volunteer_needs distribution_center
     food_pantry latitude longitude google_place_id special_needs unofficial
   ]
@@ -37,7 +34,7 @@ class Shelter < ApplicationRecord
   # columns for the outdated shelter records report view
   OutdatedViewColumnNames = %w[
     id updated_at updated_by phone accepting address address_name
-    city state county zip google_place_id notes allow_pets pets shelter
+    city county state zip google_place_id notes allow_pets pets shelter
     source supply_needs volunteer_needs distribution_center food_pantry
     latitude longitude special_needs unofficial
   ]
@@ -53,7 +50,7 @@ class Shelter < ApplicationRecord
 
   def self.to_csv
     attributes = %w[
-      shelter address city state county zip phone updated_at source accepting pets
+      shelter address city county state zip phone updated_at source accepting pets
     ]
     CSV.generate(headers: true) do |csv|
       csv << attributes

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -48,6 +48,8 @@ class Shelter < ApplicationRecord
     ShelterUpdateNotifierJob.perform_later self
   end
 
+  scope :outdated, ->(timing = 4.hours.ago) { where("updated_at < ?", timing) }
+
   def self.to_csv
     attributes = %w[
       shelter address city county state zip phone updated_at source accepting pets

--- a/app/views/amazon_products/index.html.erb
+++ b/app/views/amazon_products/index.html.erb
@@ -1,3 +1,3 @@
 <h1>Amazon Products</h1>
 
-<%= render "shared/table", rows: @amazon_products, headers: @headers, columns: @columns %>
+<%= render "shared/table", rows: @amazon_products, headers: @headers, columns: @columns, reverse_chron: false %>

--- a/app/views/api/v1/shelters/outdated.json.jbuilder
+++ b/app/views/api/v1/shelters/outdated.json.jbuilder
@@ -1,0 +1,13 @@
+json.cache! @outdated do
+  json.shelters @outdated do |shelter|
+    print shelter ? "#{shelter.id} " : '?'
+    json.cache! shelter do
+      json.partial! shelter
+    end
+  end
+end
+
+json.meta do
+  json.result_count @outdated.length
+  json.filters @filters
+end

--- a/app/views/charitable_organizations/index.html.erb
+++ b/app/views/charitable_organizations/index.html.erb
@@ -2,4 +2,4 @@
 
 <%= link_to 'Add New Charitable Organization', new_charitable_organization_path, class: "button button-outline" %>
 
-<%= render "shared/table", rows: @charitable_organizations, headers: @headers, columns: @columns %>
+<%= render "shared/table", rows: @charitable_organizations, headers: @headers, columns: @columns, reverse_chron: false %>

--- a/app/views/needs/index.html.erb
+++ b/app/views/needs/index.html.erb
@@ -26,4 +26,4 @@
 
 <%= link_to 'Add New Need', new_need_path, class: "button button-outline" %>
 
-<%= render "shared/table", rows: @needs, headers: @headers, columns: @columns %>
+<%= render "shared/table", rows: @needs, headers: @headers, columns: @columns, reverse_chron: false %>

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -30,11 +30,23 @@
   </tbody>
 </table>
 
+<% unless reverse_chron %>
 <script>
- window.onload = function() {
-   $('#data-table').DataTable({
-     "order": [[ 1, "desc" ]],
-     "stateSave": true
-   });
- };
+  window.onload = function() {
+    document.dataTable = $('#data-table').DataTable({
+      "order": [[ 1, "desc" ]],
+      "stateSave": true
+    });
+  };
 </script>
+<% else %>
+<script>
+  window.onload = function() {
+    document.dataTable = $('#data-table').DataTable({
+      "order": [[ 2, "asc" ]],
+      "stateSave": true
+    });
+    document.dataTable.order.fixed({ pre: [[ 2, "asc" ]] }).draw();
+  };
+</script>
+<% end %>

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -28,4 +28,4 @@
 <%= link_to 'Add New Shelter', new_shelter_path, class: "button button-outline" %>
 <%= link_to 'Download as CSV', shelters_path(format: :csv), class: "button button-outline" %>
 
-<%= render "shared/table", rows: @shelters, headers: @headers, columns: @columns %>
+<%= render "shared/table", rows: @shelters, headers: @headers, columns: @columns, reverse_chron: false %>

--- a/app/views/shelters/outdated.html.erb
+++ b/app/views/shelters/outdated.html.erb
@@ -1,3 +1,3 @@
 <h1>Shelters Needing Updates</h2>
 
-<%= render "shared/table", rows: @outdated, columns: @columns, headers: @headers %>
+<%= render "shared/table", rows: @outdated, columns: @columns, headers: @headers, reverse_chron: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,10 @@ Rails.application.routes.draw do
     namespace :v1 do
 
       resources :needs, only: %i[index create]
+
+      resources :shelters, only: [:index, :outdated]
       get "/shelters" => 'shelters#index'
+      get "/shelters/outdated" => 'shelters#outdated'
       get "/products" => 'amazon_products#index'
       get "/charitable_organizations" => 'charitable_organizations#index'
 


### PR DESCRIPTION
This does the following:

- Adds the `state` column to the Shelters Needing Updates view (and to all others) - closes #24 
- Fixes the default sort view on the Shelters Needing Updates view - closes #25 
- Enables a JSON API endpoint for Shelters Needing Updates at `/api/v1/shelters/outdated` - closes #26 

Review appreciated. These are pretty simple fixes, so I don't expect anything to break.