### PR TITLE
Update db/structure.sql to current state after all these merges

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -453,7 +453,8 @@ CREATE TABLE shelters (
     allow_pets boolean,
     private_sms character varying,
     private_volunteer_data_mgr character varying,
-    unofficial boolean
+    unofficial boolean,
+    accessibility text
 );
 
 
@@ -878,6 +879,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170909175503'),
 ('20170909193921'),
 ('20170910045633'),
-('20180914132709');
+('20180914132709'),
+('20180915035427');
 
 


### PR DESCRIPTION
The current [db/structure.sql](https://github.com/hurricane-response/florence-api/blob/master/db/structure.sql#L456) doesn't include the `accessibility` text field. This is not a huge deal, as rails will prompt you to run the remaining migration to add it, but this file exists to prevent that, so it'd be better if it reflected the current state of the database schema.