### PR TITLE
fix: Remove long-running import command from docker entry

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -18,8 +18,4 @@ echo
 
 bundle exec rails db:migrate
 
-if [ $RAILS_ENV = development ]; then
-  bundle exec rails api:import
-fi
-
 dockerize -wait tcp://postgresql:5432 -timeout 1s "$@"


### PR DESCRIPTION
If left in, running `docker-compose up --build` could spin for a long time and exhaust geocoding credits very quickly.  It's better to voluntarily run the import than expose users to an unexpected, potentially costly behavior.