### PR TITLE
Fix: Use 'Unknown' when shelters.allow_pets is null

### DIFF
--- a/app/views/api/v1/shelters/_shelter.json.jbuilder
+++ b/app/views/api/v1/shelters/_shelter.json.jbuilder
@@ -4,7 +4,7 @@ json.extract! shelter, :accepting, :shelter,
               :longitude, :latitude, :supply_needs, :source,
               :google_place_id, :special_needs, :id, :archived
 
-json.pets shelter.allow_pets ? 'Yes' : 'No'
+json.pets shelter.allow_pets.nil? ? 'Unknown' : (shelter.allow_pets ? 'Yes' : 'No')
 json.pets_notes shelter.pets
 json.needs((shelter.volunteer_needs || '').split(',') + (shelter.supply_needs || '').split(','))
 

--- a/test/controllers/api/v1/shelters_controller_test.rb
+++ b/test/controllers/api/v1/shelters_controller_test.rb
@@ -54,4 +54,14 @@ class Api::SheltersControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert_equal count, json['features'].length
   end
+
+  test 'returned features serials with correct pets allowed value' do
+    pets_values = %w[Yes No Unknown].freeze
+
+    get '/api/v1/shelters'
+    json = JSON.parse(response.body)
+    json['shelters'].each do |shelter|
+      assert pets_values.include?(shelter['pets'])
+    end
+  end
 end


### PR DESCRIPTION
A quick fix for when the allow_pets field is null on shelters to allow the frontend to look cleaner.